### PR TITLE
Increase init timout and re-init if the handle is invalid

### DIFF
--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -19,6 +19,9 @@ namespace HideVolumeOSD
 		[DllImport("user32.dll", SetLastError = true)]
 		static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
+        [DllImport("user32.dll")]
+        static extern bool IsWindow(IntPtr hWnd);
+
 		NotifyIcon ni;
 
 		IntPtr hWndInject = IntPtr.Zero;
@@ -118,6 +121,11 @@ namespace HideVolumeOSD
 
 		public void HideOSD()
 		{
+            if (!IsWindow(hWndInject))
+            {
+                Init();
+            }
+
 			ShowWindow(hWndInject, 6); // SW_MINIMIZE
 
 			if (ni != null)
@@ -126,6 +134,11 @@ namespace HideVolumeOSD
 
 		public void ShowOSD()
 		{
+            if (!IsWindow(hWndInject))
+            {
+                Init();
+            }
+
 			ShowWindow(hWndInject, 9); // SW_RESTORE
 
 			// show window on the screen

--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -32,16 +32,17 @@ namespace HideVolumeOSD
 		{
 			hWndInject = FindOSDWindow(true);
 
-			int count = 0;
+			int count = 1;
 
-			while (hWndInject == IntPtr.Zero && count < 5)
+			while (hWndInject == IntPtr.Zero && count < 9)
 			{
 				keybd_event((byte)Keys.VolumeUp, 0, 0, 0);
 				keybd_event((byte)Keys.VolumeDown, 0, 0, 0);
 
 				hWndInject = FindOSDWindow(true);
 
-				System.Threading.Thread.Sleep(1000);
+				// Quadratic backoff if the window is not found
+				System.Threading.Thread.Sleep(1000*(count^2));
 				count++;		
 			}
 


### PR DESCRIPTION
Hey, @UnlimitedStack 

This PR does two things:
- Increase the total timeout available if the window is not found, and make it a quadratic backoff instead of a static time between tries. This is needed as sometimes the current timout is not enough if the program is launched at startup.
- Check that the handle is still valid during the `ShowOSD`/`HideOSD`, and if it is not, then re-init. This is needed for if Windows Explorer restarts. 

Should fix all of these issues:
#1 
#5 
#7
#10