### PR TITLE
Various additions (see desc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /HideVolumeOSD/obj
 /.vs
 /x86
+/enc_temp_folder

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vs
 /x86
 /enc_temp_folder
+/HideVolumeOSD/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+/HideVolumeOSD/obj
+/.vs
+/x86

--- a/HideVolumeOSD.sln
+++ b/HideVolumeOSD.sln
@@ -1,23 +1,28 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HideVolumeOSDApp", "HideVolumeOSD\HideVolumeOSDApp.csproj", "{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|Any CPU.Build.0 = Debug|x86
+		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|x64.ActiveCfg = Debug|x64
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|x86.ActiveCfg = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|x86.Build.0 = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|Any CPU.ActiveCfg = Release|x86
+		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|x64.ActiveCfg = Release|x86
+		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|x64.Build.0 = Release|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|x86.ActiveCfg = Release|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/HideVolumeOSD.sln
+++ b/HideVolumeOSD.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32929.386
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HideVolumeOSDApp", "HideVolumeOSD\HideVolumeOSDApp.csproj", "{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}"
 EndProject
@@ -14,6 +14,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|Any CPU.Build.0 = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|x86.ActiveCfg = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Debug|x86.Build.0 = Debug|x86
 		{F317AF2E-9704-4A2A-BDAE-B4662ED9483B}.Release|Any CPU.ActiveCfg = Release|x86

--- a/HideVolumeOSD/ContextMenus.cs
+++ b/HideVolumeOSD/ContextMenus.cs
@@ -107,7 +107,14 @@ namespace HideVolumeOSD
 		{
 			if (!Settings.Default.HideOSD)
 			{
-				hideVolumeOSDLib.HideOSD();
+				if (Settings.Default.OSDHideType == 0)
+				{
+					hideVolumeOSDLib.HideOSD();
+				}
+				else
+				{
+					hideVolumeOSDLib.CloseOSD();
+				}
 				Settings.Default.HideOSD = true;
 				switchMenu.ImageIndex = 0;
 				switchMenu.Text = "Show Volume OSD";

--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -113,10 +113,10 @@ namespace HideVolumeOSD
                 return;
             }
 
-            Application.ApplicationExit += Application_ApplicationExit;
-
             if (notifyIcon != null)
             {
+                Application.ApplicationExit += Application_ApplicationExit;
+
                 if (Settings.Default.HideOSD)
                     HideOSD();
                 else
@@ -220,7 +220,7 @@ namespace HideVolumeOSD
 
         private void KeyHook_VolumeKeyPressed(object sender, EventArgs e)
         {
-            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD && !Program.SilentRun)
+            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
             {
                 hideTimer.Stop();
                 showVolumeWindow(true);

--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -8,378 +8,396 @@ using System.Windows.Forms;
 
 namespace HideVolumeOSD
 {
-	public class HideVolumeOSDLib
-	{
-		[DllImport("user32.dll")]
-		private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
+    public class HideVolumeOSDLib
+    {
+        [DllImport("user32.dll")]
+        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
 
-		[DllImport("user32.dll", SetLastError = true)]
-		private static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
-		[DllImport("user32.dll", SetLastError = true)]
-		private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
-		[DllImport("user32.dll")]
-		private static extern bool IsWindow(IntPtr hWnd);
+        [DllImport("user32.dll")]
+        private static extern bool IsWindow(IntPtr hWnd);
 
-		[DllImport("user32.dll")]
-		private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 
-		[DllImport("user32.dll", SetLastError = true)]
-		private static extern bool SystemParametersInfo(uint action, IntPtr param, [Out] out RECT rect, IntPtr init);
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SystemParametersInfo(uint action, IntPtr param, [Out] out RECT rect, IntPtr init);
 
-		[DllImport("user32.dll")]
-		static extern int GetSystemMetrics(int sm);
-
-
-		const int SM_CXSCREEN = 0;
-		const int SM_CYSCREEN = 1;
+        [DllImport("user32.dll")]
+        static extern int GetSystemMetrics(int sm);
 
 
-		const int WM_APPCOMMAND = 0x319;
-
-		const int APPCOMMAND_VOLUME_MUTE = 0x80000;
-		const int APPCOMMAND_VOLUME_DOWN = 0x90000;
-		const int APPCOMMAND_VOLUME_UP = 0xA0000;
+        const int SM_CXSCREEN = 0;
+        const int SM_CYSCREEN = 1;
 
 
-		const int SPI_GETWORKAREA = 0x0030;
+        const int WM_APPCOMMAND = 0x319;
+
+        const int APPCOMMAND_VOLUME_MUTE = 0x80000;
+        const int APPCOMMAND_VOLUME_DOWN = 0x90000;
+        const int APPCOMMAND_VOLUME_UP = 0xA0000;
 
 
-		private struct NOTIFYICONIDENTIFIER
-		{
-			public uint cbSize;
-			public IntPtr hWnd;
-			public uint uID;
-			public Guid guidItem;
-		}
-
-		[StructLayout(LayoutKind.Sequential)]
-		private struct RECT
-		{
-			public int left;
-			public int top;
-			public int right;
-			public int bottom;
-		}
-
-		[DllImport("Shell32.dll", SetLastError = true)]
-		private static extern Int32 Shell_NotifyIconGetRect([In] ref NOTIFYICONIDENTIFIER identifier, [Out] out RECT iconLocation);
-
-		NotifyIcon notifyIcon;
-		NOTIFYICONIDENTIFIER notifyIconIdentifier;
-
-		IntPtr hWndInject = IntPtr.Zero;
-	
-		VolumePoup volumePopup = new VolumePoup();
-
-		System.Windows.Forms.Timer hideTimer = new System.Windows.Forms.Timer();		
-
-		public HideVolumeOSDLib(NotifyIcon ni)
-		{
-			if (ni != null)
-			{
-				this.notifyIcon = ni;
-			}
-		}
-
-		public void Init()
-		{
-			hWndInject = FindOSDWindow(true);
-
-			int count = 1;
-
-			while (hWndInject == IntPtr.Zero && count < 9)
-			{
-				internalShowOSD(true);
-
-				hWndInject = FindOSDWindow(true);
-
-				// Quadratic backoff if the window is not found
-				System.Threading.Thread.Sleep(1000*(count^2));
-				count++;		
-			}
-
-			// final try
-
-			hWndInject = FindOSDWindow(false);
-
-			if (hWndInject == IntPtr.Zero)
-			{
-				Program.InitFailed = true;
-				return;
-			}
-
-			Application.ApplicationExit += Application_ApplicationExit;
-
-			if (notifyIcon != null)
-			{
-				if (Settings.Default.HideOSD)                                                                                                                                                                                                                       
-					HideOSD();
-				else
-					ShowOSD();				
-
-				FieldInfo idFieldInfo = notifyIcon.GetType().GetField("id", BindingFlags.NonPublic | BindingFlags.Instance);
-				int iconID = (int)idFieldInfo.GetValue(notifyIcon);
+        const int SPI_GETWORKAREA = 0x0030;
 
 
-				FieldInfo windowFieldInfo = notifyIcon.GetType().GetField("window", BindingFlags.NonPublic | BindingFlags.Instance);
-				System.Windows.Forms.NativeWindow nativeWindow = (System.Windows.Forms.NativeWindow)windowFieldInfo.GetValue(notifyIcon);
-				IntPtr iconhandle = nativeWindow.Handle;
+        private struct NOTIFYICONIDENTIFIER
+        {
+            public uint cbSize;
+            public IntPtr hWnd;
+            public uint uID;
+            public Guid guidItem;
+        }
 
-				notifyIconIdentifier = new NOTIFYICONIDENTIFIER()
-				{
-					hWnd = iconhandle,
-					uID = (uint)iconID
-				};
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
 
-				notifyIconIdentifier.cbSize = (uint)Marshal.SizeOf(notifyIconIdentifier);
-			}
+        [DllImport("Shell32.dll", SetLastError = true)]
+        private static extern Int32 Shell_NotifyIconGetRect([In] ref NOTIFYICONIDENTIFIER identifier, [Out] out RECT iconLocation);
+
+        NotifyIcon notifyIcon;
+        NOTIFYICONIDENTIFIER notifyIconIdentifier;
+
+        IntPtr hWndInject = IntPtr.Zero;
+
+        VolumePoup volumePopup = new VolumePoup();
+
+        System.Windows.Forms.Timer hideTimer = new System.Windows.Forms.Timer();
+
+        public HideVolumeOSDLib(NotifyIcon ni)
+        {
+            if (ni != null)
+            {
+                this.notifyIcon = ni;
+            }
+        }
+
+        public void Init()
+        {
+            hWndInject = FindOSDWindow(true);
+
+            int count = 1;
+
+            while (hWndInject == IntPtr.Zero && count < 9)
+            {
+                internalShowOSD(true);
+
+                hWndInject = FindOSDWindow(true);
+
+                // Quadratic backoff if the window is not found
+                System.Threading.Thread.Sleep(1000 * (count ^ 2));
+                count++;
+            }
+
+            // final try
+
+            hWndInject = FindOSDWindow(false);
+
+            if (hWndInject == IntPtr.Zero)
+            {
+                Program.InitFailed = true;
+                return;
+            }
+
+            Application.ApplicationExit += Application_ApplicationExit;
+
+            if (notifyIcon != null)
+            {
+                if (Settings.Default.HideOSD)
+                    HideOSD();
+                else
+                    ShowOSD();
+
+                FieldInfo idFieldInfo = notifyIcon.GetType().GetField("id", BindingFlags.NonPublic | BindingFlags.Instance);
+                int iconID = (int)idFieldInfo.GetValue(notifyIcon);
+
+
+                FieldInfo windowFieldInfo = notifyIcon.GetType().GetField("window", BindingFlags.NonPublic | BindingFlags.Instance);
+                System.Windows.Forms.NativeWindow nativeWindow = (System.Windows.Forms.NativeWindow)windowFieldInfo.GetValue(notifyIcon);
+                IntPtr iconhandle = nativeWindow.Handle;
+
+                notifyIconIdentifier = new NOTIFYICONIDENTIFIER()
+                {
+                    hWnd = iconhandle,
+                    uID = (uint)iconID
+                };
+
+                notifyIconIdentifier.cbSize = (uint)Marshal.SizeOf(notifyIconIdentifier);
+            }
 
             KeyHook.VolumeKeyPressed += KeyHook_VolumeKeyPressed;
             KeyHook.VolumeKeyReleased += KeyHook_VolumeKeyReleased;
-			
-			KeyHook.StartListening();
-			
-            hideTimer.Tick += HideTimer_Tick;			
-		}
+            KeyHook.HotKeyReleased += KeyHook_HotKeyReleased;
+
+            KeyHook.StartListening();
+
+            hideTimer.Tick += HideTimer_Tick;
+        }
 
         private IntPtr FindOSDWindow(bool bSilent)
-		{
-			IntPtr hwndOSD = IntPtr.Zero;
-
-			String build = RuntimeInformation.OSDescription.Substring(RuntimeInformation.OSDescription.LastIndexOf('.') + 1);
-			int buildNumber = int.Parse(build);
-
-			if (buildNumber >= 22000)
-            {
-				hwndOSD = internalFind(bSilent, "XamlExplorerHostIslandWindow", "", "Windows.UI.Composition.DesktopWindowContentBridge", "DesktopWindowXamlSource"); 
-			}
-            else 
-			{
-				hwndOSD = internalFind(bSilent, "NativeHWNDHost", "", "DirectUIHWND", "");
-			}
-			
-			// if no window found yet, there is no OSD window at all
-
-			if (hwndOSD == IntPtr.Zero && !bSilent)
-			{
-				ShowMessage("Sorry, the OSD window could not be found! Application is closed...", ToolTipIcon.Error);
-			}
-
-			return hwndOSD;
-		}
-
-		private IntPtr internalFind(bool bSilent, String outerClass, String outerName, String innerClass, String innerName)
         {
-			IntPtr hwndFound = IntPtr.Zero;
-			IntPtr hwndOSD = IntPtr.Zero;
+            IntPtr hwndOSD = IntPtr.Zero;
 
-			int pairCount = 0;
+            String build = RuntimeInformation.OSDescription.Substring(RuntimeInformation.OSDescription.LastIndexOf('.') + 1);
+            int buildNumber = int.Parse(build);
 
-			// search for all windows with with outClass and outerName
-
-			while ((hwndFound = FindWindowEx(IntPtr.Zero, hwndFound, outerClass, outerName)) != IntPtr.Zero)
-			{
-				// search for all child windows with with innerClass and innerName
-
-				if (FindWindowEx(hwndFound, IntPtr.Zero, innerClass, innerName) != IntPtr.Zero)
-				{
-					// if this is the only pair we are sure
-
-					if (pairCount == 0)
-					{
-						hwndOSD = hwndFound;
-					}
-
-					pairCount++;
-
-					// if there are more pairs the criteria has failed...
-
-					if (pairCount > 1)
-					{
-						//ShowMessage("OSD window not clearly found,\nmultiple pairs exist!\nApplication is closed...", ToolTipIcon.Error);
-						//return IntPtr.Zero;
-					}
-				}
-			}
-
-			return hwndOSD;
-		}
-
-		private void Application_ApplicationExit(object sender, EventArgs e)
-		{
-			volumePopup.Stop();
-			KeyHook.StopListening();
-			ShowOSD();
-		}
-
-		private void KeyHook_VolumeKeyPressed(object sender, EventArgs e)
-		{			
-			if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
-			{
-				hideTimer.Stop();
-				showVolumeWindow(true);
-			}
-		}
-		
-		private void KeyHook_VolumeKeyReleased(object sender, EventArgs e)
-		{
-			if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
-			{
-				hideTimer.Interval = Settings.Default.VolumeHideDelay;
-				hideTimer.Start();
-			}
-		}
-
-		private void HideTimer_Tick(object sender, EventArgs e)
-		{
-			hideTimer.Stop();
-
-			if (Settings.Default.VolumeInSystemTray)
-			{
-				showVolumeWindow(false);
-			}
-		}
-
-		public void HideOSD()
-		{
-            if (!IsWindow(hWndInject))
+            if (buildNumber >= 22000)
             {
-                Init();
+                hwndOSD = internalFind(bSilent, "XamlExplorerHostIslandWindow", "", "Windows.UI.Composition.DesktopWindowContentBridge", "DesktopWindowXamlSource");
+            }
+            else
+            {
+                hwndOSD = internalFind(bSilent, "NativeHWNDHost", "", "DirectUIHWND", "");
             }
 
-			ShowWindow(hWndInject, 6); // SW_MINIMIZE
+            // if no window found yet, there is no OSD window at all
 
-			if (notifyIcon != null)
-				notifyIcon.Icon = Resources.IconDisabled;
-		}
-
-		private void internalShowOSD(bool init = false)
-        {
-			float volume = volumePopup.getVolume();
-
-			hideTimer.Stop();
-			showVolumeWindow(false);
-
-			if (volume == 1)
-			{
-				if (init)
-				{
-					keybd_event((byte)Keys.VolumeUp, 0, 0, 0);
-				}
-				else
-				{
-					SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_UP);
-				}
-			}
-			else
-			{
-				if (init)
-				{
-					keybd_event((byte)Keys.VolumeUp, 0, 0, 0);
-					keybd_event((byte)Keys.VolumeDown, 0, 0, 0);
-				}
-				else
-				{
-					SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_UP);
-					SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_DOWN);
-				}
-			}
-		}
-
-		public void ShowOSD()
-		{
-            if (!IsWindow(hWndInject))
+            if (hwndOSD == IntPtr.Zero && !bSilent)
             {
-                Init();
+                ShowMessage("Sorry, the OSD window could not be found! Application is closed...", ToolTipIcon.Error);
             }
 
-			ShowWindow(hWndInject, 9); // SW_RESTORE
+            return hwndOSD;
+        }
 
-			// show window on the screen
-
-			internalShowOSD();
-			
-			if (notifyIcon != null)
-				notifyIcon.Icon = Resources.Icon;
-		}
-
-		public void ShowMessage(String message, ToolTipIcon icon)
+        private IntPtr internalFind(bool bSilent, String outerClass, String outerName, String innerClass, String innerName)
         {
-			notifyIcon.ShowBalloonTip(5000, "HideVolumeOSD", message, icon);
+            IntPtr hwndFound = IntPtr.Zero;
+            IntPtr hwndOSD = IntPtr.Zero;
 
-			long tickCountEnd = Environment.TickCount + 5000;
-			
-			while (Environment.TickCount < tickCountEnd)
-			{
-				Application.DoEvents();
-			}
-		}
+            int pairCount = 0;
 
-		public void showVolumeWindow(bool bShow)
-        {
-			if (bShow)
+            // search for all windows with with outClass and outerName
+
+            while ((hwndFound = FindWindowEx(IntPtr.Zero, hwndFound, outerClass, outerName)) != IntPtr.Zero)
             {
-				RECT rect = new RECT();
+                // search for all child windows with with innerClass and innerName
 
-				bool bOverIcon = false;
-
-				if (Shell_NotifyIconGetRect(ref notifyIconIdentifier, out rect) != 0 || Settings.Default.VolumeDisplayNearClock)
-				{
-					RECT rcDesktop = new RECT();
-					SystemParametersInfo(SPI_GETWORKAREA, IntPtr.Zero, out rcDesktop, IntPtr.Zero);
-
-					int cx = GetSystemMetrics(SM_CXSCREEN);
-					int cy = GetSystemMetrics(SM_CYSCREEN);
-
-					int taskBarHeight = cy - rcDesktop.bottom;
-
-					rect.left = (int)(cx - taskBarHeight * 1.8);
-					rect.right = cx;
-
-					rect.top = rcDesktop.bottom;
-					rect.bottom = cy;
-				}
-				else
+                if (FindWindowEx(hwndFound, IntPtr.Zero, innerClass, innerName) != IntPtr.Zero)
                 {
-					bOverIcon = true;
+                    // if this is the only pair we are sure
+
+                    if (pairCount == 0)
+                    {
+                        hwndOSD = hwndFound;
+                    }
+
+                    pairCount++;
+
+                    // if there are more pairs the criteria has failed...
+
+                    if (pairCount > 1)
+                    {
+                        //ShowMessage("OSD window not clearly found,\nmultiple pairs exist!\nApplication is closed...", ToolTipIcon.Error);
+                        //return IntPtr.Zero;
+                    }
+                }
+            }
+
+            return hwndOSD;
+        }
+
+        private void Application_ApplicationExit(object sender, EventArgs e)
+        {
+            volumePopup.Stop();
+            KeyHook.StopListening();
+            ShowOSD();
+        }
+
+        private void KeyHook_VolumeKeyPressed(object sender, EventArgs e)
+        {
+            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
+            {
+                hideTimer.Stop();
+                showVolumeWindow(true);
+            }
+        }
+
+        private void KeyHook_VolumeKeyReleased(object sender, EventArgs e)
+        {
+            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
+            {
+                hideTimer.Interval = Settings.Default.VolumeHideDelay;
+                hideTimer.Start();
+            }
+        }
+
+        private void KeyHook_HotKeyReleased(object sender, EventArgs e)
+        {
+            if (Settings.Default.VolumeInSystemTray && Settings.Default.VolumeDisplayHotkeyEnabled)
+            {
+                if (Settings.Default.HideOSD)
+                {
+                    ShowOSD();
+                    Settings.Default.HideOSD = false;
+                }
+                else
+                {
+                    HideOSD();
+                    Settings.Default.HideOSD = true;
+                }
+            }
+        }
+
+        private void HideTimer_Tick(object sender, EventArgs e)
+        {
+            hideTimer.Stop();
+
+            if (Settings.Default.VolumeInSystemTray)
+            {
+                showVolumeWindow(false);
+            }
+        }
+
+        public void HideOSD()
+        {
+            if (!IsWindow(hWndInject))
+            {
+                Init();
+            }
+
+            ShowWindow(hWndInject, 6); // SW_MINIMIZE
+
+            if (notifyIcon != null)
+                notifyIcon.Icon = Resources.IconDisabled;
+        }
+
+        private void internalShowOSD(bool init = false)
+        {
+            float volume = volumePopup.getVolume();
+
+            hideTimer.Stop();
+            showVolumeWindow(false);
+
+            if (volume == 1)
+            {
+                if (init)
+                {
+                    keybd_event((byte)Keys.VolumeUp, 0, 0, 0);
+                }
+                else
+                {
+                    SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_UP);
+                }
+            }
+            else
+            {
+                if (init)
+                {
+                    keybd_event((byte)Keys.VolumeUp, 0, 0, 0);
+                    keybd_event((byte)Keys.VolumeDown, 0, 0, 0);
+                }
+                else
+                {
+                    SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_UP);
+                    SendMessage(IntPtr.Zero, WM_APPCOMMAND, IntPtr.Zero, (IntPtr)APPCOMMAND_VOLUME_DOWN);
+                }
+            }
+        }
+
+        public void ShowOSD()
+        {
+            if (!IsWindow(hWndInject))
+            {
+                Init();
+            }
+
+            ShowWindow(hWndInject, 9); // SW_RESTORE
+
+            // show window on the screen
+
+            internalShowOSD();
+
+            if (notifyIcon != null)
+                notifyIcon.Icon = Resources.Icon;
+        }
+
+        public void ShowMessage(String message, ToolTipIcon icon)
+        {
+            notifyIcon.ShowBalloonTip(5000, "HideVolumeOSD", message, icon);
+
+            long tickCountEnd = Environment.TickCount + 5000;
+
+            while (Environment.TickCount < tickCountEnd)
+            {
+                Application.DoEvents();
+            }
+        }
+
+        public void showVolumeWindow(bool bShow)
+        {
+            if (bShow)
+            {
+                RECT rect = new RECT();
+
+                bool bOverIcon = false;
+
+                if (Shell_NotifyIconGetRect(ref notifyIconIdentifier, out rect) != 0 || Settings.Default.VolumeDisplayNearClock)
+                {
+                    RECT rcDesktop = new RECT();
+                    SystemParametersInfo(SPI_GETWORKAREA, IntPtr.Zero, out rcDesktop, IntPtr.Zero);
+
+                    int cx = GetSystemMetrics(SM_CXSCREEN);
+                    int cy = GetSystemMetrics(SM_CYSCREEN);
+
+                    int taskBarHeight = cy - rcDesktop.bottom;
+
+                    rect.left = (int)(cx - taskBarHeight * 1.8);
+                    rect.right = cx;
+
+                    rect.top = rcDesktop.bottom;
+                    rect.bottom = cy;
+                }
+                else
+                {
+                    bOverIcon = true;
                 }
 
-				int height = rect.bottom - rect.top;
+                int height = rect.bottom - rect.top;
 
-				switch (Settings.Default.VolumeDisplaySize)
-				{
-					case 0:
+                switch (Settings.Default.VolumeDisplaySize)
+                {
+                    case 0:
 
-						height = (int)(height / 2.75);
-						break;
+                        height = (int)(height / 2.75);
+                        break;
 
-					case 1:
+                    case 1:
 
-						height = (int)(height / 2);
-						break;
+                        height = (int)(height / 2);
+                        break;
 
-					case 2:
+                    case 2:
 
-						height = (int)(height / 1.2);
-						break;
-				}
+                        height = (int)(height / 1.2);
+                        break;
+                }
 
-				int width = (int)(height * 1.8);
+                int width = (int)(height * 1.8);
 
-				volumePopup.Show();
-				volumePopup.Size = new Size(width, height);
+                volumePopup.Show();
+                volumePopup.Size = new Size(width, height);
 
-				if (bOverIcon)
-					volumePopup.Location = new Point(rect.left + (rect.right - rect.left) / 2 - width / 2, rect.top + (rect.bottom - rect.top) / 2 - height / 2);
-				else
-					volumePopup.Location = new Point(rect.right - width - Settings.Default.VolumeDisplayOffset, rect.top + (rect.bottom - rect.top) / 2 - height / 2);
-			}
-			else
-            {
-				volumePopup.Hide();
+                if (bOverIcon)
+                    volumePopup.Location = new Point(rect.left + (rect.right - rect.left) / 2 - width / 2, rect.top + (rect.bottom - rect.top) / 2 - height / 2);
+                else
+                    volumePopup.Location = new Point(rect.right - width - Settings.Default.VolumeDisplayOffset, rect.top + (rect.bottom - rect.top) / 2 - height / 2);
             }
-		}
-	}
+            else
+            {
+                volumePopup.Hide();
+            }
+        }
+    }
 }

--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -238,7 +238,7 @@ namespace HideVolumeOSD
 
         private void KeyHook_HotKeyReleased(object sender, EventArgs e)
         {
-            if (Settings.Default.VolumeInSystemTray && Settings.Default.VolumeDisplayHotkeyEnabled)
+            if (Settings.Default.VolumeDisplayHotkeyEnabled)
             {
                 if (Settings.Default.HideOSD)
                 {
@@ -334,6 +334,9 @@ namespace HideVolumeOSD
             }
 
             CloseWindow(hWndInject);
+
+            if (notifyIcon != null && !Program.SilentRun)
+                notifyIcon.Icon = Resources.IconDisabled;
         }
 
         public void ShowMessage(String message, ToolTipIcon icon)

--- a/HideVolumeOSD/HideVolumeOSDLib.cs
+++ b/HideVolumeOSD/HideVolumeOSDLib.cs
@@ -19,6 +19,9 @@ namespace HideVolumeOSD
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool CloseWindow(IntPtr hWnd);
+
         [DllImport("user32.dll")]
         private static extern bool IsWindow(IntPtr hWnd);
 
@@ -217,7 +220,7 @@ namespace HideVolumeOSD
 
         private void KeyHook_VolumeKeyPressed(object sender, EventArgs e)
         {
-            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD)
+            if (Settings.Default.VolumeInSystemTray && Settings.Default.HideOSD && !Program.SilentRun)
             {
                 hideTimer.Stop();
                 showVolumeWindow(true);
@@ -321,6 +324,16 @@ namespace HideVolumeOSD
 
             if (notifyIcon != null)
                 notifyIcon.Icon = Resources.Icon;
+        }
+
+        public void CloseOSD()
+        {
+            if (!IsWindow(hWndInject))
+            {
+                Init();
+            }
+
+            CloseWindow(hWndInject);
         }
 
         public void ShowMessage(String message, ToolTipIcon icon)

--- a/HideVolumeOSD/KeyHook.cs
+++ b/HideVolumeOSD/KeyHook.cs
@@ -30,6 +30,7 @@ namespace HideVolumeOSD
 
         public static event EventHandler VolumeKeyPressed = delegate {};
         public static event EventHandler VolumeKeyReleased = delegate {};
+        public static event EventHandler HotKeyReleased = delegate {};
 
         public static void StartListening()
         {
@@ -62,13 +63,25 @@ namespace HideVolumeOSD
                             VolumeKeyPressed(null, EventArgs.Empty);
                         }
                     }
-                    else
-                    if (wParam == (IntPtr)WM_KEYUP)
+                    else if (wParam == (IntPtr)WM_KEYUP)
                     {
                         if (VolumeKeyReleased != null)
                         {
                             VolumeKeyReleased(null, EventArgs.Empty);
                         }
+                    }
+                }
+            } 
+            else if (Settings.Default.VolumeDisplayHotkeyEnabled)
+            {
+                string formattedKey = Settings.Default.VolumeDisplayHotkey.ToString().ToUpperInvariant();
+                int key = char.Parse(formattedKey);
+
+                if (vkCode == key)
+                {
+                    if (wParam == (IntPtr)WM_KEYUP && !UserSettings.IsActive)
+                    {
+                        HotKeyReleased(null, EventArgs.Empty);
                     }
                 }
             }

--- a/HideVolumeOSD/KeyHook.cs
+++ b/HideVolumeOSD/KeyHook.cs
@@ -71,15 +71,22 @@ namespace HideVolumeOSD
                         }
                     }
                 }
-            } 
+            }
+            // Sets the hotkey if the user settings page is active and the text to enter a hotkey is in focus
+            else if (UserSettings.GetFormActive() && UserSettings.GetHotboxKeyFocused())
+            {
+                Keys key = (Keys)Keys.Parse(typeof(Keys), (vkCode).ToString());
+                Settings.Default.VolumeDisplayHotkey = key.ToString();
+            }
+            // Triggers the hotkey if the toggle hotkey option is enabled
             else if (Settings.Default.VolumeDisplayHotkeyEnabled)
             {
-                string formattedKey = Settings.Default.VolumeDisplayHotkey.ToString().ToUpperInvariant();
-                int key = char.Parse(formattedKey);
+                string formattedKey = Settings.Default.VolumeDisplayHotkey;
+                int key = (int)Keys.Parse(typeof(Keys), formattedKey);
 
                 if (vkCode == key)
                 {
-                    if (wParam == (IntPtr)WM_KEYUP && !UserSettings.IsActive)
+                    if (wParam == (IntPtr)WM_KEYUP && !UserSettings.GetFormActive())
                     {
                         HotKeyReleased(null, EventArgs.Empty);
                     }

--- a/HideVolumeOSD/KeyHook.cs
+++ b/HideVolumeOSD/KeyHook.cs
@@ -73,14 +73,14 @@ namespace HideVolumeOSD
                 }
             }
             // Triggers the hotkey if the toggle hotkey option is enabled
-            else if (Settings.Default.VolumeDisplayHotkeyEnabled)
+            else if (Settings.Default.VolumeDisplayHotkeyEnabled && !UserSettings.GetFormActive())
             {
                 string formattedKey = Settings.Default.VolumeDisplayHotkey;
                 int key = (int)Keys.Parse(typeof(Keys), formattedKey);
 
                 if (vkCode == key)
                 {
-                    if (wParam == (IntPtr)WM_KEYUP && !UserSettings.GetFormActive())
+                    if (wParam == (IntPtr)WM_KEYUP)
                     {
                         HotKeyReleased(null, EventArgs.Empty);
                     }

--- a/HideVolumeOSD/KeyHook.cs
+++ b/HideVolumeOSD/KeyHook.cs
@@ -72,12 +72,6 @@ namespace HideVolumeOSD
                     }
                 }
             }
-            // Sets the hotkey if the user settings page is active and the text to enter a hotkey is in focus
-            else if (UserSettings.GetFormActive() && UserSettings.GetHotboxKeyFocused())
-            {
-                Keys key = (Keys)Keys.Parse(typeof(Keys), (vkCode).ToString());
-                Settings.Default.VolumeDisplayHotkey = key.ToString();
-            }
             // Triggers the hotkey if the toggle hotkey option is enabled
             else if (Settings.Default.VolumeDisplayHotkeyEnabled)
             {

--- a/HideVolumeOSD/Program.cs
+++ b/HideVolumeOSD/Program.cs
@@ -5,57 +5,60 @@ using System.Threading;
 
 namespace HideVolumeOSD
 {
-	/// <summary>
-	/// 
-	/// </summary>
-	static class Program
-	{
-		public static bool InitFailed = false;
+    /// <summary>
+    /// 
+    /// </summary>
+    static class Program
+    {
+        public static bool InitFailed = false;
+        public static bool SilentRun = false;
 
-		static Mutex mutex = new Mutex(true, "{00A827A1-C8D4-4FAF-A79B-0193AF81249B}");
+        static Mutex mutex = new Mutex(true, "{00A827A1-C8D4-4FAF-A79B-0193AF81249B}");
 
-		/// <summary>
-		/// The main entry point for the application.
-		/// </summary>
-		[STAThread]
-		static void Main(string[] args)
-		{
-			if (mutex.WaitOne(TimeSpan.Zero, true))
-			{
-				if ((args.GetLength(0) == 1))
-				{
-					HideVolumeOSDLib lib = new HideVolumeOSDLib(null);
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main(string[] args)
+        {
+            if (mutex.WaitOne(TimeSpan.Zero, true))
+            {
+                if ((args.Length == 1))
+                {
+                    HideVolumeOSDLib lib = new HideVolumeOSDLib(null);
 
-					lib.Init();
+                    lib.Init();
 
-					if (args[0] == "-hide")
-					{
-						lib.HideOSD();
-					}
-					else
-						if (args[0] == "-show")
-						{
-							lib.ShowOSD();
-						}
+                    if (args[0] == "-silent")
+                    {
+                        lib.CloseOSD();
+                        SilentRun = true;
+                    }
+                    else if (args[0] == "-hide")
+                    {
+                        lib.HideOSD();
+                    }
+                    else if (args[0] == "-show")
+                    {
+                        lib.ShowOSD();
+                    }
+                }
+                else
+                {
+                    Application.EnableVisualStyles();
+                    Application.SetCompatibleTextRenderingDefault(false);
 
-					Application.Exit();
-				}
-				else
-				{					
-					Application.EnableVisualStyles();
-					Application.SetCompatibleTextRenderingDefault(false);
+                    using (ProcessIcon pi = new ProcessIcon())
+                    {
+                        pi.Display();
 
-					using (ProcessIcon pi = new ProcessIcon())
-					{
-						pi.Display();
+                        if (!InitFailed)
+                            Application.Run();
+                    }
+                }
 
-						if (!InitFailed)
-							Application.Run();
-					}
-				}
-
-				mutex.ReleaseMutex();				
-			}
-		}
-	}
+                mutex.ReleaseMutex();
+            }
+        }
+    }
 }

--- a/HideVolumeOSD/Program.cs
+++ b/HideVolumeOSD/Program.cs
@@ -23,7 +23,7 @@ namespace HideVolumeOSD
         {
             if (mutex.WaitOne(TimeSpan.Zero, true))
             {
-                if ((args.Length == 1))
+                if (args.Length == 1)
                 {
                     HideVolumeOSDLib lib = new HideVolumeOSDLib(null);
 
@@ -32,7 +32,6 @@ namespace HideVolumeOSD
                     if (args[0] == "-silent")
                     {
                         lib.CloseOSD();
-                        SilentRun = true;
                     }
                     else if (args[0] == "-hide")
                     {
@@ -42,6 +41,7 @@ namespace HideVolumeOSD
                     {
                         lib.ShowOSD();
                     }
+                    Application.Exit();
                 }
                 else
                 {

--- a/HideVolumeOSD/Program.cs
+++ b/HideVolumeOSD/Program.cs
@@ -32,6 +32,7 @@ namespace HideVolumeOSD
                     if (args[0] == "-silent")
                     {
                         lib.CloseOSD();
+                        SilentRun = true;
                     }
                     else if (args[0] == "-hide")
                     {

--- a/HideVolumeOSD/Properties/AssemblyInfo.cs
+++ b/HideVolumeOSD/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/HideVolumeOSD/Settings.Designer.cs
+++ b/HideVolumeOSD/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HideVolumeOSD {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -104,6 +104,29 @@ namespace HideVolumeOSD {
             }
             set {
                 this["VolumeDisplayOffset"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public char VolumeDisplayHotkey {
+            get {
+                return ((char)(this["VolumeDisplayHotkey"]));
+            }
+            set {
+                this["VolumeDisplayHotkey"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool VolumeDisplayHotkeyEnabled {
+            get {
+                return ((bool)(this["VolumeDisplayHotkeyEnabled"]));
+            }
+            set {
+                this["VolumeDisplayHotkeyEnabled"] = value;
             }
         }
     }

--- a/HideVolumeOSD/Settings.Designer.cs
+++ b/HideVolumeOSD/Settings.Designer.cs
@@ -130,5 +130,17 @@ namespace HideVolumeOSD {
                 this["VolumeDisplayHotkeyEnabled"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int OSDHideType {
+            get {
+                return ((int)(this["OSDHideType"]));
+            }
+            set {
+                this["OSDHideType"] = value;
+            }
+        }
     }
 }

--- a/HideVolumeOSD/Settings.Designer.cs
+++ b/HideVolumeOSD/Settings.Designer.cs
@@ -109,9 +109,10 @@ namespace HideVolumeOSD {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        public char VolumeDisplayHotkey {
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string VolumeDisplayHotkey {
             get {
-                return ((char)(this["VolumeDisplayHotkey"]));
+                return ((string)(this["VolumeDisplayHotkey"]));
             }
             set {
                 this["VolumeDisplayHotkey"] = value;

--- a/HideVolumeOSD/Settings.settings
+++ b/HideVolumeOSD/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="VolumeDisplayHotkeyEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="OSDHideType" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/HideVolumeOSD/Settings.settings
+++ b/HideVolumeOSD/Settings.settings
@@ -23,5 +23,11 @@
     <Setting Name="VolumeDisplayOffset" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">32</Value>
     </Setting>
+    <Setting Name="VolumeDisplayHotkey" Type="System.Char" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="VolumeDisplayHotkeyEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/HideVolumeOSD/Settings.settings
+++ b/HideVolumeOSD/Settings.settings
@@ -23,7 +23,7 @@
     <Setting Name="VolumeDisplayOffset" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">32</Value>
     </Setting>
-    <Setting Name="VolumeDisplayHotkey" Type="System.Char" Scope="User">
+    <Setting Name="VolumeDisplayHotkey" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="VolumeDisplayHotkeyEnabled" Type="System.Boolean" Scope="User">

--- a/HideVolumeOSD/UserSettings.Designer.cs
+++ b/HideVolumeOSD/UserSettings.Designer.cs
@@ -31,6 +31,11 @@ namespace HideVolumeOSD
         {
             this.components = new System.ComponentModel.Container();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.textBoxToggleHotkey = new System.Windows.Forms.TextBox();
+            this.checkBoxToggleHotkey = new System.Windows.Forms.CheckBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.textBoxOffset = new System.Windows.Forms.TextBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.radioButtonBig = new System.Windows.Forms.RadioButton();
             this.radioButtonMedium = new System.Windows.Forms.RadioButton();
@@ -46,9 +51,7 @@ namespace HideVolumeOSD
             this.label3 = new System.Windows.Forms.Label();
             this.checkBoxSystemTrayVolume = new System.Windows.Forms.CheckBox();
             this.buttonClose = new System.Windows.Forms.Button();
-            this.textBoxOffset = new System.Windows.Forms.TextBox();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.label4 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -57,6 +60,9 @@ namespace HideVolumeOSD
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.label5);
+            this.groupBox1.Controls.Add(this.textBoxToggleHotkey);
+            this.groupBox1.Controls.Add(this.checkBoxToggleHotkey);
             this.groupBox1.Controls.Add(this.label4);
             this.groupBox1.Controls.Add(this.textBoxOffset);
             this.groupBox1.Controls.Add(this.groupBox3);
@@ -70,10 +76,56 @@ namespace HideVolumeOSD
             this.groupBox1.Controls.Add(this.checkBoxSystemTrayVolume);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(407, 235);
+            this.groupBox1.Size = new System.Drawing.Size(407, 308);
             this.groupBox1.TabIndex = 3;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Sytem tray volume display";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(88, 272);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(24, 13);
+            this.label5.TabIndex = 17;
+            this.label5.Text = "key";
+            // 
+            // textBoxToggleHotkey
+            // 
+            this.textBoxToggleHotkey.Location = new System.Drawing.Point(34, 270);
+            this.textBoxToggleHotkey.Name = "textBoxToggleHotkey";
+            this.textBoxToggleHotkey.Size = new System.Drawing.Size(48, 20);
+            this.textBoxToggleHotkey.TabIndex = 16;
+            this.textBoxToggleHotkey.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxToggleHotkey_KeyPress);
+            // 
+            // checkBoxToggleHotkey
+            // 
+            this.checkBoxToggleHotkey.AutoSize = true;
+            this.checkBoxToggleHotkey.Location = new System.Drawing.Point(11, 247);
+            this.checkBoxToggleHotkey.Name = "checkBoxToggleHotkey";
+            this.checkBoxToggleHotkey.Size = new System.Drawing.Size(94, 17);
+            this.checkBoxToggleHotkey.TabIndex = 15;
+            this.checkBoxToggleHotkey.Text = "Toggle hotkey";
+            this.checkBoxToggleHotkey.UseVisualStyleBackColor = true;
+            this.checkBoxToggleHotkey.CheckedChanged += new System.EventHandler(this.checkBoxToggleHotkey_CheckedChanged);
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(88, 194);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(103, 13);
+            this.label4.TabIndex = 14;
+            this.label4.Text = "pixel offset from right";
+            // 
+            // textBoxOffset
+            // 
+            this.textBoxOffset.Location = new System.Drawing.Point(34, 192);
+            this.textBoxOffset.Name = "textBoxOffset";
+            this.textBoxOffset.Size = new System.Drawing.Size(48, 20);
+            this.textBoxOffset.TabIndex = 13;
+            this.textBoxOffset.TextChanged += new System.EventHandler(this.textBoxOffset_TextChanged);
+            this.textBoxOffset.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxOffset_KeyPress);
             // 
             // groupBox3
             // 
@@ -234,7 +286,7 @@ namespace HideVolumeOSD
             // 
             // buttonClose
             // 
-            this.buttonClose.Location = new System.Drawing.Point(344, 253);
+            this.buttonClose.Location = new System.Drawing.Point(344, 326);
             this.buttonClose.Name = "buttonClose";
             this.buttonClose.Size = new System.Drawing.Size(75, 23);
             this.buttonClose.TabIndex = 4;
@@ -242,34 +294,16 @@ namespace HideVolumeOSD
             this.buttonClose.UseVisualStyleBackColor = true;
             this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
             // 
-            // textBoxOffset
-            // 
-            this.textBoxOffset.Location = new System.Drawing.Point(34, 192);
-            this.textBoxOffset.Name = "textBoxOffset";
-            this.textBoxOffset.Size = new System.Drawing.Size(48, 20);
-            this.textBoxOffset.TabIndex = 13;
-            this.textBoxOffset.TextChanged += new System.EventHandler(this.textBoxOffset_TextChanged);
-            this.textBoxOffset.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxOffset_KeyPress);
-            // 
             // contextMenuStrip1
             // 
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(61, 4);
             // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(88, 195);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(103, 13);
-            this.label4.TabIndex = 14;
-            this.label4.Text = "pixel offset from right";
-            // 
             // UserSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(431, 285);
+            this.ClientSize = new System.Drawing.Size(431, 358);
             this.Controls.Add(this.buttonClose);
             this.Controls.Add(this.groupBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
@@ -279,6 +313,7 @@ namespace HideVolumeOSD
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.Text = "Settings";
+            this.Load += new System.EventHandler(this.UserSettings_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.groupBox3.ResumeLayout(false);
@@ -310,5 +345,8 @@ namespace HideVolumeOSD
         private System.Windows.Forms.TextBox textBoxOffset;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.CheckBox checkBoxToggleHotkey;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox textBoxToggleHotkey;
     }
 }

--- a/HideVolumeOSD/UserSettings.Designer.cs
+++ b/HideVolumeOSD/UserSettings.Designer.cs
@@ -92,11 +92,14 @@ namespace HideVolumeOSD
             // 
             // textBoxToggleHotkey
             // 
+            this.textBoxToggleHotkey.Enabled = false;
             this.textBoxToggleHotkey.Location = new System.Drawing.Point(34, 270);
             this.textBoxToggleHotkey.Name = "textBoxToggleHotkey";
             this.textBoxToggleHotkey.Size = new System.Drawing.Size(48, 20);
             this.textBoxToggleHotkey.TabIndex = 16;
+            this.textBoxToggleHotkey.Enter += new System.EventHandler(this.textBoxToggleHotkey_Enter);
             this.textBoxToggleHotkey.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxToggleHotkey_KeyPress);
+            this.textBoxToggleHotkey.Leave += new System.EventHandler(this.textBoxToggleHotkey_Leave);
             // 
             // checkBoxToggleHotkey
             // 

--- a/HideVolumeOSD/UserSettings.Designer.cs
+++ b/HideVolumeOSD/UserSettings.Designer.cs
@@ -100,6 +100,7 @@ namespace HideVolumeOSD
             this.textBoxToggleHotkey.Enter += new System.EventHandler(this.textBoxToggleHotkey_Enter);
             this.textBoxToggleHotkey.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxToggleHotkey_KeyPress);
             this.textBoxToggleHotkey.Leave += new System.EventHandler(this.textBoxToggleHotkey_Leave);
+            this.textBoxToggleHotkey.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.textBoxToggleHotkey_PreviewKeyDown);
             // 
             // checkBoxToggleHotkey
             // 

--- a/HideVolumeOSD/UserSettings.Designer.cs
+++ b/HideVolumeOSD/UserSettings.Designer.cs
@@ -31,6 +31,9 @@ namespace HideVolumeOSD
         {
             this.components = new System.ComponentModel.Container();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.radioButtonClose = new System.Windows.Forms.RadioButton();
+            this.radioButtonMinimize = new System.Windows.Forms.RadioButton();
             this.label5 = new System.Windows.Forms.Label();
             this.textBoxToggleHotkey = new System.Windows.Forms.TextBox();
             this.checkBoxToggleHotkey = new System.Windows.Forms.CheckBox();
@@ -53,6 +56,7 @@ namespace HideVolumeOSD
             this.buttonClose = new System.Windows.Forms.Button();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.groupBox1.SuspendLayout();
+            this.groupBox4.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarDelay)).BeginInit();
@@ -60,6 +64,7 @@ namespace HideVolumeOSD
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.groupBox4);
             this.groupBox1.Controls.Add(this.label5);
             this.groupBox1.Controls.Add(this.textBoxToggleHotkey);
             this.groupBox1.Controls.Add(this.checkBoxToggleHotkey);
@@ -80,6 +85,41 @@ namespace HideVolumeOSD
             this.groupBox1.TabIndex = 3;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Sytem tray volume display";
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.radioButtonClose);
+            this.groupBox4.Controls.Add(this.radioButtonMinimize);
+            this.groupBox4.Location = new System.Drawing.Point(274, 218);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(119, 80);
+            this.groupBox4.TabIndex = 12;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "OSD hide type";
+            // 
+            // radioButtonClose
+            // 
+            this.radioButtonClose.AutoSize = true;
+            this.radioButtonClose.Location = new System.Drawing.Point(17, 46);
+            this.radioButtonClose.Name = "radioButtonClose";
+            this.radioButtonClose.Size = new System.Drawing.Size(51, 17);
+            this.radioButtonClose.TabIndex = 9;
+            this.radioButtonClose.TabStop = true;
+            this.radioButtonClose.Text = "Close";
+            this.radioButtonClose.UseVisualStyleBackColor = true;
+            this.radioButtonClose.CheckedChanged += new System.EventHandler(this.radioButtonClose_CheckedChanged);
+            // 
+            // radioButtonMinimize
+            // 
+            this.radioButtonMinimize.AutoSize = true;
+            this.radioButtonMinimize.Location = new System.Drawing.Point(17, 23);
+            this.radioButtonMinimize.Name = "radioButtonMinimize";
+            this.radioButtonMinimize.Size = new System.Drawing.Size(65, 17);
+            this.radioButtonMinimize.TabIndex = 8;
+            this.radioButtonMinimize.TabStop = true;
+            this.radioButtonMinimize.Text = "Minimize";
+            this.radioButtonMinimize.UseVisualStyleBackColor = true;
+            this.radioButtonMinimize.CheckedChanged += new System.EventHandler(this.radioButtonMinimize_CheckedChanged);
             // 
             // label5
             // 
@@ -136,9 +176,9 @@ namespace HideVolumeOSD
             this.groupBox3.Controls.Add(this.radioButtonBig);
             this.groupBox3.Controls.Add(this.radioButtonMedium);
             this.groupBox3.Controls.Add(this.radioButtonSmall);
-            this.groupBox3.Location = new System.Drawing.Point(291, 121);
+            this.groupBox3.Location = new System.Drawing.Point(274, 107);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(102, 100);
+            this.groupBox3.Size = new System.Drawing.Size(119, 100);
             this.groupBox3.TabIndex = 12;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Size of display";
@@ -183,9 +223,9 @@ namespace HideVolumeOSD
             // 
             this.groupBox2.Controls.Add(this.radioButtonDark);
             this.groupBox2.Controls.Add(this.radioButtonLight);
-            this.groupBox2.Location = new System.Drawing.Point(291, 29);
+            this.groupBox2.Location = new System.Drawing.Point(274, 15);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(102, 80);
+            this.groupBox2.Size = new System.Drawing.Size(119, 80);
             this.groupBox2.TabIndex = 11;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Display style";
@@ -320,6 +360,8 @@ namespace HideVolumeOSD
             this.Load += new System.EventHandler(this.UserSettings_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
             this.groupBox2.ResumeLayout(false);
@@ -352,5 +394,8 @@ namespace HideVolumeOSD
         private System.Windows.Forms.CheckBox checkBoxToggleHotkey;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox textBoxToggleHotkey;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.RadioButton radioButtonClose;
+        private System.Windows.Forms.RadioButton radioButtonMinimize;
     }
 }

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -6,7 +6,9 @@ namespace HideVolumeOSD
 {
     public partial class UserSettings : Form
     {
-        public static bool IsActive;
+        private static bool IsActive;
+        private static bool HotkeyBoxFocused;
+
         public UserSettings()
         {
             InitializeComponent();
@@ -19,6 +21,19 @@ namespace HideVolumeOSD
             radioButtonDark.Checked = !Settings.Default.VolumeDisplayLight;
             textBoxOffset.Text = Settings.Default.VolumeDisplayOffset.ToString();
             checkBoxToggleHotkey.Checked = Settings.Default.VolumeDisplayHotkeyEnabled;
+            textBoxToggleHotkey.Text = Settings.Default.VolumeDisplayHotkey;
+        }
+
+        // Used to ensure the user settings form is open
+        public static bool GetFormActive()
+        {
+            return IsActive;
+        }
+
+        // Used to ensure the hotkey is read only when the text box related to it is in focus
+        public static bool GetHotboxKeyFocused()
+        {
+            return HotkeyBoxFocused;
         }
 
         protected override void OnVisibleChanged(EventArgs e)
@@ -42,6 +57,7 @@ namespace HideVolumeOSD
         {
             base.OnClosed(e);
             Settings.Default.Save();
+            IsActive = false;
         }
 
         private void trackBarDelay_Scroll(object sender, EventArgs e)
@@ -155,7 +171,7 @@ namespace HideVolumeOSD
 
         private void textBoxOffset_KeyPress(object sender, KeyPressEventArgs e)
         {
-            Keys key = (Keys)Enum.Parse(typeof(Keys), ((int)e.KeyChar).ToString());
+            Keys key = (Keys)Keys.Parse(typeof(Keys), ((int)e.KeyChar).ToString());
             if (key == Keys.Back && textBoxOffset.Text.Length <= 1)
             {
                 e.Handled = true;
@@ -169,9 +185,18 @@ namespace HideVolumeOSD
 
         private void textBoxToggleHotkey_KeyPress(object sender, KeyPressEventArgs e)
         {
+            textBoxToggleHotkey.Text = Settings.Default.VolumeDisplayHotkey;
             e.Handled = true;
-            textBoxToggleHotkey.Text = e.KeyChar.ToString();
-            Settings.Default.VolumeDisplayHotkey = e.KeyChar;
+        }
+
+        private void textBoxToggleHotkey_Enter(object sender, EventArgs e)
+        {
+            HotkeyBoxFocused = true;
+        }
+
+        private void textBoxToggleHotkey_Leave(object sender, EventArgs e)
+        {
+            HotkeyBoxFocused = false;
         }
     }
 }

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -6,6 +6,7 @@ namespace HideVolumeOSD
 {
     public partial class UserSettings : Form
     {
+        public static bool IsActive;
         public UserSettings()
         {
             InitializeComponent();
@@ -17,6 +18,7 @@ namespace HideVolumeOSD
             radioButtonLight.Checked = Settings.Default.VolumeDisplayLight;
             radioButtonDark.Checked = !Settings.Default.VolumeDisplayLight;
             textBoxOffset.Text = Settings.Default.VolumeDisplayOffset.ToString();
+            checkBoxToggleHotkey.Checked = Settings.Default.VolumeDisplayHotkeyEnabled;
         }
 
         protected override void OnVisibleChanged(EventArgs e)
@@ -28,6 +30,12 @@ namespace HideVolumeOSD
                 Rectangle rect = Screen.FromHandle(this.Handle).Bounds;
                 Location = new Point(rect.Width - this.Width - 64, rect.Height - this.Height - 96);
             }
+        }
+
+
+        private void UserSettings_Load(object sender, EventArgs e)
+        {
+            IsActive = true;
         }
 
         protected override void OnClosed(EventArgs e)
@@ -57,26 +65,7 @@ namespace HideVolumeOSD
         private void buttonClose_Click(object sender, EventArgs e)
         {
             Close();
-        }
-
-        private int GetCheckedIndex()
-        {
-            if (radioButtonSmall.Checked)
-            {
-                return 0;
-            }
-            else
-                if (radioButtonMedium.Checked)
-                {
-                    return 1;
-                }
-                else
-                    if (radioButtonBig.Checked)
-                    {
-                        return 2;
-                    }
-
-            return 0;
+            IsActive = false;
         }
 
         private void SetChecked(int value)
@@ -131,6 +120,13 @@ namespace HideVolumeOSD
             Settings.Default.VolumeDisplayNearClock = checkBoxClockPos.Checked;
         }
 
+
+        private void checkBoxToggleHotkey_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.VolumeDisplayHotkeyEnabled = checkBoxToggleHotkey.Checked;
+            textBoxToggleHotkey.Enabled = checkBoxToggleHotkey.Checked;
+        }
+
         private void radioButtonLight_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Default.VolumeDisplayLight = radioButtonLight.Checked;
@@ -169,6 +165,13 @@ namespace HideVolumeOSD
             {
                 e.Handled = true;
             }
+        }
+
+        private void textBoxToggleHotkey_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            e.Handled = true;
+            textBoxToggleHotkey.Text = e.KeyChar.ToString();
+            Settings.Default.VolumeDisplayHotkey = e.KeyChar;
         }
     }
 }

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -15,10 +15,12 @@ namespace HideVolumeOSD
 
             checkBoxSystemTrayVolume.Checked = Settings.Default.VolumeInSystemTray;
             trackBarDelay.Value = Settings.Default.VolumeHideDelay;
-            SetChecked(Settings.Default.VolumeDisplaySize);
+            SetDisplaySizeChecked(Settings.Default.VolumeDisplaySize);
             checkBoxClockPos.Checked = Settings.Default.VolumeDisplayNearClock;
             radioButtonLight.Checked = Settings.Default.VolumeDisplayLight;
             radioButtonDark.Checked = !Settings.Default.VolumeDisplayLight;
+            radioButtonMinimize.Checked = Settings.Default.OSDHideType == 0 ? true : false;
+            radioButtonClose.Checked = Settings.Default.OSDHideType == 1 ? true : false;
             textBoxOffset.Text = Settings.Default.VolumeDisplayOffset.ToString();
             checkBoxToggleHotkey.Checked = Settings.Default.VolumeDisplayHotkeyEnabled;
             textBoxToggleHotkey.Text = Settings.Default.VolumeDisplayHotkey;
@@ -81,11 +83,11 @@ namespace HideVolumeOSD
     
         private void buttonClose_Click(object sender, EventArgs e)
         {
-            Close();
             IsActive = false;
+            Close();
         }
 
-        private void SetChecked(int value)
+        private void SetDisplaySizeChecked(int value)
         {
             switch (value)
             {
@@ -106,13 +108,14 @@ namespace HideVolumeOSD
             }
 
             Settings.Default.VolumeDisplaySize = value;
+            Settings.Default.Save();
         }
 
         private void radioButtonSmall_CheckedChanged(object sender, EventArgs e)
         {
             if (radioButtonSmall.Checked)
             {
-                SetChecked(0);
+                SetDisplaySizeChecked(0);
             }
         }
 
@@ -120,7 +123,7 @@ namespace HideVolumeOSD
         {
             if (radioButtonMedium.Checked)
             {
-                SetChecked(1);
+                SetDisplaySizeChecked(1);
             }
         }
 
@@ -128,13 +131,14 @@ namespace HideVolumeOSD
         {
             if (radioButtonBig.Checked)
             {
-                SetChecked(2);
+                SetDisplaySizeChecked(2);
             }
         }
 
         private void checkBoxClockPos_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Default.VolumeDisplayNearClock = checkBoxClockPos.Checked;
+            Settings.Default.Save();
         }
 
 
@@ -142,16 +146,19 @@ namespace HideVolumeOSD
         {
             Settings.Default.VolumeDisplayHotkeyEnabled = checkBoxToggleHotkey.Checked;
             textBoxToggleHotkey.Enabled = checkBoxToggleHotkey.Checked;
+            Settings.Default.Save();
         }
 
         private void radioButtonLight_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Default.VolumeDisplayLight = radioButtonLight.Checked;
+            Settings.Default.Save();
         }
 
         private void radioButtonDark_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Default.VolumeDisplayLight = radioButtonLight.Checked;
+            Settings.Default.Save();
         }
 
         private void textBoxOffset_TextChanged(object sender, EventArgs e)
@@ -203,6 +210,18 @@ namespace HideVolumeOSD
         {
             textBoxToggleHotkey.Text = e.KeyData.ToString();
             Settings.Default.VolumeDisplayHotkey = e.KeyData.ToString();
+            Settings.Default.Save();
+        }
+
+        private void radioButtonMinimize_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.OSDHideType = 0;
+            Settings.Default.Save();
+        }
+
+        private void radioButtonClose_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.OSDHideType = 1;
             Settings.Default.Save();
         }
     }

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -156,7 +156,6 @@ namespace HideVolumeOSD
 
         private void textBoxOffset_TextChanged(object sender, EventArgs e)
         {
-            Settings.Default.VolumeDisplayOffset = int.Parse(textBoxOffset.Text);
             // Used if the user selects all text in the text box then erases the contents
             bool validNumber = int.TryParse(textBoxOffset.Text, out int value);
             if (validNumber)
@@ -172,6 +171,7 @@ namespace HideVolumeOSD
 
         private void textBoxOffset_KeyPress(object sender, KeyPressEventArgs e)
         {
+            // Used if the backspace key was entered and there is less than or equal to 1 character in the text box
             Keys key = (Keys)Keys.Parse(typeof(Keys), ((int)e.KeyChar).ToString());
             if (key == Keys.Back && textBoxOffset.Text.Length <= 1)
             {

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -144,11 +144,28 @@ namespace HideVolumeOSD
         private void textBoxOffset_TextChanged(object sender, EventArgs e)
         {
             Settings.Default.VolumeDisplayOffset = int.Parse(textBoxOffset.Text);
+            // Used if the user selects all text in the text box then erases the contents
+            bool validNumber = int.TryParse(textBoxOffset.Text, out int value);
+            if (validNumber)
+            {
+                Settings.Default.VolumeDisplayOffset = int.Parse(textBoxOffset.Text);
+            }
+            else
+            {
+                Settings.Default.VolumeDisplayOffset = 0;
+                textBoxOffset.Text = "0";
+            }
         }
 
         private void textBoxOffset_KeyPress(object sender, KeyPressEventArgs e)
         {
-            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
+            Keys key = (Keys)Enum.Parse(typeof(Keys), ((int)e.KeyChar).ToString());
+            if (key == Keys.Back && textBoxOffset.Text.Length <= 1)
+            {
+                e.Handled = true;
+                textBoxOffset.Text = "0";
+            }
+            if ((!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar)))
             {
                 e.Handled = true;
             }

--- a/HideVolumeOSD/UserSettings.cs
+++ b/HideVolumeOSD/UserSettings.cs
@@ -22,6 +22,7 @@ namespace HideVolumeOSD
             textBoxOffset.Text = Settings.Default.VolumeDisplayOffset.ToString();
             checkBoxToggleHotkey.Checked = Settings.Default.VolumeDisplayHotkeyEnabled;
             textBoxToggleHotkey.Text = Settings.Default.VolumeDisplayHotkey;
+            KeyPreview = true;
         }
 
         // Used to ensure the user settings form is open
@@ -185,7 +186,6 @@ namespace HideVolumeOSD
 
         private void textBoxToggleHotkey_KeyPress(object sender, KeyPressEventArgs e)
         {
-            textBoxToggleHotkey.Text = Settings.Default.VolumeDisplayHotkey;
             e.Handled = true;
         }
 
@@ -197,6 +197,13 @@ namespace HideVolumeOSD
         private void textBoxToggleHotkey_Leave(object sender, EventArgs e)
         {
             HotkeyBoxFocused = false;
+        }
+
+        private void textBoxToggleHotkey_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+        {
+            textBoxToggleHotkey.Text = e.KeyData.ToString();
+            Settings.Default.VolumeDisplayHotkey = e.KeyData.ToString();
+            Settings.Default.Save();
         }
     }
 }

--- a/HideVolumeOSD/VolumePoup.Designer.cs
+++ b/HideVolumeOSD/VolumePoup.Designer.cs
@@ -46,7 +46,6 @@ namespace HideVolumeOSD
             this.ShowInTaskbar = false;
             this.TopMost = true;
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/HideVolumeOSD/VolumePoup.cs
+++ b/HideVolumeOSD/VolumePoup.cs
@@ -26,10 +26,12 @@ namespace HideVolumeOSD
             popup = this;
             threadVolume.Start();
         }
+
         public void Stop()
         {
             threadVolume.Abort();
         }
+
         public void updateValueSafe()
         {
             if (this.InvokeRequired)

--- a/HideVolumeOSD/VolumePoup.cs
+++ b/HideVolumeOSD/VolumePoup.cs
@@ -39,7 +39,7 @@ namespace HideVolumeOSD
             }
             else
             {
-                volume = ((int)(getVolume() * 100)).ToString();
+                volume = Math.Round(getVolume() * 100, MidpointRounding.ToEven).ToString();
                 Refresh();
             }            
         }

--- a/HideVolumeOSD/app.config
+++ b/HideVolumeOSD/app.config
@@ -28,6 +28,12 @@
             <setting name="VolumeDisplayOffset" serializeAs="String">
                 <value>32</value>
             </setting>
+            <setting name="VolumeDisplayHotkey" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="VolumeDisplayHotkeyEnabled" serializeAs="String">
+                <value>False</value>
+            </setting>
         </HideVolumeOSD.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/HideVolumeOSD/app.config
+++ b/HideVolumeOSD/app.config
@@ -34,6 +34,9 @@
             <setting name="VolumeDisplayHotkeyEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="OSDHideType" serializeAs="String">
+                <value>0</value>
+            </setting>
         </HideVolumeOSD.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/README.md
+++ b/README.md
@@ -2,20 +2,23 @@
 
 ### Hides the Windows 10/11 volume bar that appears when changing volume.
 
-More Information: [Site](http://wordpress.venturi.de/?p=1)
+More information: [Site](http://wordpress.venturi.de/?p=1)
 
 Latest version: [Version](http://wordpress.venturi.de/?p=379)
 
 ## How to download and build the project
 
-1. Download and Install Visual Studio [here](https://visualstudio.microsoft.com/)
-2. Download and Install Git Bash [here](https://git-scm.com/downloads)
-3. Clone down this project to your local machine. `git clone https://github.com/DeltaReckoner/HideVolumeOSD.git`
-4. Open up the `HideVolumeOSD.sln` in Visual Studio
-5. Right click on the Solution in the `Solution Explorer` and go to `Properties`
+1. Download and Install Visual Studio [here](https://visualstudio.microsoft.com/).
+2. Download and Install Git Bash [here](https://git-scm.com/downloads).
+3. Clone down this project to your local machine.
+
+![image](https://github.com/user-attachments/assets/cbddaf1e-5f8b-46b0-8a7b-686624f2446e)
+
+5. Open up the `HideVolumeOSD.sln` in Visual Studio.
+6. Right click on the Solution in the `Solution Explorer` and go to `Properties`.
 
 ![image](https://github.com/user-attachments/assets/28be143f-c88a-4a3e-ad4f-ef0fe288282b)
 
-7. Go to `Configuration Properties` and check the Build checkbox in the project context
+7. Go to `Configuration Properties` and check the Build checkbox in the project context.
    
 ![image](https://github.com/user-attachments/assets/ce3ab0a8-c275-48f2-97b2-aac7dcb3c407)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # HideVolumeOSD
 
-Hides the Windows 10/11 volume bar that appears when changing volume.
+### Hides the Windows 10/11 volume bar that appears when changing volume.
 
-More information about that available at...
+More Information: [Site](http://wordpress.venturi.de/?p=1)
 
-http://wordpress.venturi.de/?p=1 
+Latest version: [Version](http://wordpress.venturi.de/?p=379)
 
-Latest version
+## How to download and build the project
 
-http://wordpress.venturi.de/?p=379
+1. Download and Install Visual Studio [here](https://visualstudio.microsoft.com/)
+2. Download and Install Git Bash [here](https://git-scm.com/downloads)
+3. Clone down this project to your local machine. `git clone https://github.com/DeltaReckoner/HideVolumeOSD.git`
+4. Open up the `HideVolumeOSD.sln` in Visual Studio
+5. Right click on the Solution in the `Solution Explorer` and go to `Properties`
+
+![image](https://github.com/user-attachments/assets/28be143f-c88a-4a3e-ad4f-ef0fe288282b)
+
+7. Go to `Configuration Properties` and check the Build checkbox in the project context
+   
+![image](https://github.com/user-attachments/assets/ce3ab0a8-c275-48f2-97b2-aac7dcb3c407)


### PR DESCRIPTION
Added:
- Hotkey support.
- Silent command line option. (Uses `CloseWindow(IntPtr hwNd)`).
- OSD hide type setting. (`Minimize` uses `ShowWindow(IntPtr hWnd)`, `Close` uses  `CloseWindow(IntPtr hwNd)`).

Fixed:
- Certain numbers displayed as a decimal with the volume pop-up on system tray option on Windows 11.
- Removing all input from "Show near Time" setting caused a program to throw an exception.

Notes:
- Using the "-silent" in command line or "Close" as the hide type will correct issues with stuttering on monitors that support a variable refresh rate (GSync, FreeSync, etc) on most games/cases.